### PR TITLE
Make activation idempotent, add tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
 gem 'puppet', puppetversion
-gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'puppetlabs_spec_helper', '>= 1.2.1'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0'

--- a/manifests/activation.pp
+++ b/manifests/activation.pp
@@ -9,39 +9,45 @@ class deepsecurityagent::activation (
 ) inherits deepsecurityagent {
   debug("tenantid is ${dsmtenantid}")
   debug("tenantpassword is ${dsmtenantpassword}")
-  $dsmheartbeaturl = "dsm://${dsmheartbeataddress}:${dsmheartbeatport}/"
+
+  $dsmheartbeaturl = "dsm://${deepsecurityagent::dsmheartbeataddress}:${deepsecurityagent::dsmheartbeatport}/"
+
   if $dsmtenantid == '' {
-  	$tenantarguments = ''
+    $tenantarguments = ''
   }
   else {
-  	$tenantarguments = "\"tenantID:${dsmtenantid}\" \"tenantPassword:${dsmtenantpassword}\""
+    $tenantarguments = "\"tenantID:${dsmtenantid}\" \"tenantPassword:${dsmtenantpassword}\""
   }
+
   if $policyid == '' {
-  	$policyargument = ''
+    $policyargument = ''
   }
   else {
-  	$policyargument = "\"policyid:${policyid}\""
+    $policyargument = "\"policyid:${policyid}\""
   }
+
   $arguments = "${tenantarguments} ${policyargument}"
+
   if $::osfamily != 'windows' {
-    exec {"sleep":
-      command => "sleep 15",
-      path => "/usr/bin:/bin",
+    exec {'sleep':
+      command => 'sleep 15',
+      path    => '/usr/bin:/bin',
       creates => $deepsecurityagent::params::dsa_config_file,
     }
   }
   else {
-  	exec {"sleep":
-    command => 'ping 127.0.0.1 -n 50',
-    path => $::path,
-    creates => $deepsecurityagent::params::dsa_config_file,
-      }
+    exec {'sleep':
+      command => 'ping 127.0.0.1 -n 50',
+      path    => $::path,
+      creates => $deepsecurityagent::params::dsa_config_file,
     }
-  debug("activation command is ${deepsecurityagent::params::dsa_control} -a ${dsmheartbeaturl} ${arguments}")
-  exec { "Deep Security Agent Activation":
-    command => "${deepsecurityagent::params::dsa_control} -a ${dsmheartbeaturl} ${arguments}",
-    require => Exec["sleep"],
-    creates => $deepsecurityagent::params::dsa_config_file,
-    }
+  }
 
+  debug("activation command is ${deepsecurityagent::params::dsa_control} -a ${dsmheartbeaturl} ${arguments}")
+
+  exec { 'Deep Security Agent Activation':
+    command => "${deepsecurityagent::params::dsa_control} -a ${dsmheartbeaturl} ${arguments}",
+    require => Exec['sleep'],
+    creates => $deepsecurityagent::params::dsa_config_file,
+  }
 }

--- a/manifests/activation.pp
+++ b/manifests/activation.pp
@@ -7,8 +7,8 @@ class deepsecurityagent::activation (
   $dsmtenantpassword = $deepsecurityagent::dsmtenantpassword,
   $policyid = $deepsecurityagent::policyid,
 ) inherits deepsecurityagent {
-	notice ("tenantid is ${dsmtenantid}")
-  notice ("tenantpassword is ${dsmtenantpassword}")
+  debug("tenantid is ${dsmtenantid}")
+  debug("tenantpassword is ${dsmtenantpassword}")
   $dsmheartbeaturl = "dsm://${dsmheartbeataddress}:${dsmheartbeatport}/"
   if $dsmtenantid == '' {
   	$tenantarguments = ''
@@ -37,7 +37,7 @@ class deepsecurityagent::activation (
     creates => $deepsecurityagent::params::dsa_config_file,
       }
     }
-  notice ("activation command is ${deepsecurityagent::params::dsa_control} -a ${dsmheartbeaturl} ${arguments}")
+  debug("activation command is ${deepsecurityagent::params::dsa_control} -a ${dsmheartbeaturl} ${arguments}")
   exec { "Deep Security Agent Activation":
     command => "${deepsecurityagent::params::dsa_control} -a ${dsmheartbeaturl} ${arguments}",
     require => Exec["sleep"],

--- a/manifests/activation.pp
+++ b/manifests/activation.pp
@@ -27,18 +27,21 @@ class deepsecurityagent::activation (
     exec {"sleep":
       command => "sleep 15",
       path => "/usr/bin:/bin",
+      creates => $deepsecurityagent::params::dsa_config_file,
     }
   }
   else {
   	exec {"sleep":
     command => 'ping 127.0.0.1 -n 50',
     path => $::path,
+    creates => $deepsecurityagent::params::dsa_config_file,
       }
     }
   notice ("activation command is ${deepsecurityagent::params::dsa_control} -a ${dsmheartbeaturl} ${arguments}")
   exec { "Deep Security Agent Activation":
     command => "${deepsecurityagent::params::dsa_control} -a ${dsmheartbeaturl} ${arguments}",
     require => Exec["sleep"],
+    creates => $deepsecurityagent::params::dsa_config_file,
     }
 
 }

--- a/manifests/control.pp
+++ b/manifests/control.pp
@@ -1,8 +1,7 @@
 # Define: deepsecurityagent::control
- # Parameters:
- # arguments
- #
- define deepsecurityagent::control (arguments) {
- 	# puppet code
- 	
- } 
+# Parameters:
+# arguments
+#
+define deepsecurityagent::control () {
+  # puppet code
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@ class deepsecurityagent (
   $activate = false,
 ) inherits deepsecurityagent::params {
 
-  notice ("called with activation = $activate")
+  debug("called with activation = $activate")
   if $activate == false {
 
     class { '::deepsecurityagent::install': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -131,7 +131,7 @@ class deepsecurityagent::install inherits deepsecurityagent {
         ensure => 'installed',
         source => "${::env_windows_installdir}\\agent.msi",
         require => Exec["Download_Windows_Agent"]
-        
+
       }
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 class deepsecurityagent::install inherits deepsecurityagent {
   $dsmurl = "https://${dsmconsoleaddress}:${dsmconsoleport}/software/agent"
 
-  notice("Install Class determine OS" )
+  debug('Install Class determine OS')
 
   case $::operatingsystem {
     'windows' : {
@@ -66,7 +66,7 @@ class deepsecurityagent::install inherits deepsecurityagent {
     default: { fail("Please check to ensure you are running an operating system supported by Deep Security Agent and this module") }
   }
 
-  notice("Downloading agent from ${agentsource}")
+  debug("Downloading agent from ${agentsource}")
 
   case $::osfamily {
     'Redhat', 'CentOS', 'Amazon', 'Linux' :{

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,47 +1,48 @@
 class deepsecurityagent::params {
-  $dsmconsoleaddress    = "app.deepsecurity.trendmicro.com"
-  $dsmagentaddress      = "agents.deepsecurity.trendmicro.com"
-  $dsmheartbeatport     = "443"
-  $dsmconsoleport       = "443"
+  $dsmconsoleaddress    = 'app.deepsecurity.trendmicro.com'
+  $dsmagentaddress      = 'agents.deepsecurity.trendmicro.com'
+  $dsmheartbeatport     = '443'
+  $dsmconsoleport       = '443'
   $dsmtenantid          = ''
   $dsmtenantpassword    = ''
   $policyid             = ''
 
   case $::osfamily {
     'windows' : {
-      $dsa_control      = '"C:\Program Files\Trend Micro\Deep Security Agent\dsa_control.cmd"'
-      $agentpackage = 'Trend Micro Deep Security Agent'
-      $agentservice = 'ds_agent'
+      $dsa_control     = '"C:\Program Files\Trend Micro\Deep Security Agent\dsa_control.cmd"'
+      $agentpackage    = 'Trend Micro Deep Security Agent'
+      $agentservice    = 'ds_agent'
       $dsa_config_file = 'C:/ProgramData/Trend Micro/Deep Security Agent/dsa_core/ds_agent.config'
     }
     'Suse' : {
-      $dsa_control      = '/opt/ds_agent/dsa_control'
-      $agentpackage = 'ds_agent'
-      $agentservice = 'ds_agent'
+      $dsa_control     = '/opt/ds_agent/dsa_control'
+      $agentpackage    = 'ds_agent'
+      $agentservice    = 'ds_agent'
       $dsa_config_file = '/var/opt/ds_agent/dsa_core/ds_agent.config'
     }
     'RedHat' : {
-      $dsa_control    = '/opt/ds_agent/dsa_control'
-      $agentpackage = 'ds_agent'
-      $agentservice = 'ds_agent'
+      $dsa_control     = '/opt/ds_agent/dsa_control'
+      $agentpackage    = 'ds_agent'
+      $agentservice    = 'ds_agent'
       $dsa_config_file = '/var/opt/ds_agent/dsa_core/ds_agent.config'
     }
     'Debian' : {
-      $dsa_control    = '/opt/ds_agent/dsa_control'
-      $agentpackage = 'ds-agent'
-      $agentservice = 'ds_agent'
+      $dsa_control     = '/opt/ds_agent/dsa_control'
+      $agentpackage    = 'ds-agent'
+      $agentservice    = 'ds_agent'
       $dsa_config_file = '/var/opt/ds_agent/dsa_core/ds_agent.config'
     }
     #prior to facter 1.7, facter returns 'Linux' for ::osfamily on amazon linux
     'Linux' : {
       case $::operatingsystem {
-         'Amazon': {
-            $dsa_control    = '/opt/ds_agent/dsa_control'
-            $agentpackage = 'ds_agent'
-            $agentservice = 'ds_agent'
-            $dsa_config_file = '/var/opt/ds_agent/dsa_core/ds_agent.config'
-	 }
+        'Amazon': {
+          $dsa_control     = '/opt/ds_agent/dsa_control'
+          $agentpackage    = 'ds_agent'
+          $agentservice    = 'ds_agent'
+          $dsa_config_file = '/var/opt/ds_agent/dsa_core/ds_agent.config'
+        }
       }
     }
+    default: { fail('Operating system is not supported by this module') }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,21 +12,25 @@ class deepsecurityagent::params {
       $dsa_control      = '"C:\Program Files\Trend Micro\Deep Security Agent\dsa_control.cmd"'
       $agentpackage = 'Trend Micro Deep Security Agent'
       $agentservice = 'ds_agent'
+      $dsa_config_file = 'C:/ProgramData/Trend Micro/Deep Security Agent/dsa_core/ds_agent.config'
     }
     'Suse' : {
       $dsa_control      = '/opt/ds_agent/dsa_control'
       $agentpackage = 'ds_agent'
       $agentservice = 'ds_agent'
+      $dsa_config_file = '/var/opt/ds_agent/dsa_core/ds_agent.config'
     }
     'RedHat' : {
       $dsa_control    = '/opt/ds_agent/dsa_control'
       $agentpackage = 'ds_agent'
       $agentservice = 'ds_agent'
+      $dsa_config_file = '/var/opt/ds_agent/dsa_core/ds_agent.config'
     }
     'Debian' : {
       $dsa_control    = '/opt/ds_agent/dsa_control'
       $agentpackage = 'ds-agent'
       $agentservice = 'ds_agent'
+      $dsa_config_file = '/var/opt/ds_agent/dsa_core/ds_agent.config'
     }
     #prior to facter 1.7, facter returns 'Linux' for ::osfamily on amazon linux
     'Linux' : {
@@ -35,6 +39,7 @@ class deepsecurityagent::params {
             $dsa_control    = '/opt/ds_agent/dsa_control'
             $agentpackage = 'ds_agent'
             $agentservice = 'ds_agent'
+            $dsa_config_file = '/var/opt/ds_agent/dsa_core/ds_agent.config'
 	 }
       }
     }

--- a/spec/classes/activation_spec.rb
+++ b/spec/classes/activation_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+describe 'deepsecurityagent::activation' do
+  shared_context 'a successful linux activation' do
+    let(:dsa_control_command) do
+      '/opt/ds_agent/dsa_control -a dsm://agents.deepsecurity.trendmicro.com:443/'
+    end
+
+    it do
+      is_expected.to contain_exec('Deep Security Agent Activation').with(
+        'command' => "#{dsa_control_command}  ",
+        'creates' => '/var/opt/ds_agent/dsa_core/ds_agent.config'
+      )
+        .that_requires('Exec[sleep]')
+    end
+
+    it do
+      is_expected.to contain_exec('sleep').with(
+        'command' => 'sleep 15',
+        'creates' => '/var/opt/ds_agent/dsa_core/ds_agent.config'
+      )
+        .that_comes_before('Exec[Deep Security Agent Activation]')
+    end
+  end
+
+  shared_context 'successfully handle parameters' do
+    context 'with policyid' do
+      let(:params) { { policyid: 99 } }
+
+      it do
+        is_expected.to contain_exec('Deep Security Agent Activation')
+          .with_command(%(#{dsa_control_command}  "policyid:99"))
+      end
+    end
+
+    context 'with tenant parameters' do
+      let(:params) do
+        { dsmtenantid: 'foo', dsmtenantpassword: 'bar' }
+      end
+
+      it do
+        is_expected.to contain_exec('Deep Security Agent Activation')
+          .with_command(%(#{dsa_control_command} "tenantID:foo" "tenantPassword:bar" ))
+      end
+    end
+
+    context 'with policyid and tenant parameters' do
+      let(:params) do
+        { dsmtenantid: 'foo', dsmtenantpassword: 'bar', policyid: 99 }
+      end
+
+      it do
+        is_expected.to contain_exec('Deep Security Agent Activation')
+          .with_command(%(#{dsa_control_command} "tenantID:foo" "tenantPassword:bar" "policyid:99"))
+      end
+    end
+  end
+
+  context 'on RedHat distributions' do
+    let(:facts) do
+      {
+        osfamily: 'RedHat',
+        operatingsystem: 'RedHat',
+        architecture: 'x86_64'
+      }
+    end
+
+    include_context 'a successful linux activation'
+    include_context 'successfully handle parameters'
+  end
+
+  context 'on Ubuntu distributions' do
+    let(:facts) do
+      {
+        osfamily: 'Debian',
+        operatingsystem: 'Ubuntu',
+        architecture: 'x86_64'
+      }
+    end
+
+    include_context 'a successful linux activation'
+    include_context 'successfully handle parameters'
+  end
+
+  context 'on Suse distributions' do
+    let(:facts) do
+      {
+        osfamily: 'Suse',
+        operatingsystem: 'SLES',
+        architecture: 'x86_64'
+      }
+    end
+
+    include_context 'a successful linux activation'
+    include_context 'successfully handle parameters'
+  end
+
+  context 'on Windows' do
+    let(:dsa_control_command) do
+      '"C:\\Program Files\\Trend Micro\\Deep Security Agent\\dsa_control.cmd" -a dsm://agents.deepsecurity.trendmicro.com:443/'
+    end
+
+    let(:facts) do
+      {
+        osfamily: 'windows',
+        operatingsystem: 'Windows',
+        architecture: 'x64'
+      }
+    end
+
+    it do
+      is_expected.to contain_exec('Deep Security Agent Activation').with(
+        'command' => "#{dsa_control_command}  ",
+        'creates' => 'C:/ProgramData/Trend Micro/Deep Security Agent/dsa_core/ds_agent.config'
+      )
+    end
+
+    it do
+      is_expected.to contain_exec('sleep').with(
+        'command' => 'ping 127.0.0.1 -n 50',
+        'creates' => 'C:/ProgramData/Trend Micro/Deep Security Agent/dsa_core/ds_agent.config'
+      )
+    end
+
+    include_context 'successfully handle parameters'
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,89 @@
 require 'spec_helper'
-describe 'deepsecurityagent' do
 
-  context 'with defaults for all parameters' do
-    it { should contain_class('deepsecurityagent') }
+describe 'deepsecurityagent' do
+  shared_context 'a successful compile and common tests' do |package_name|
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('deepsecurityagent') }
+    it { is_expected.to contain_package(package_name).with_ensure('installed') }
+    it { is_expected.to contain_service('ds_agent').with_ensure('running') }
+    context 'with default value for activate' do
+      it { is_expected.not_to contain_class('deepsecurityagent::activation') }
+    end
+
+    context 'with activate set to true' do
+      let(:params) { { activate: true } }
+      it { is_expected.to contain_class('deepsecurityagent::activation') }
+    end
+  end
+
+  context 'on RedHat distributions' do
+    let(:facts) do
+      {
+        osfamily: 'RedHat',
+        operatingsystem: 'RedHat',
+        architecture: 'x86_64'
+      }
+    end
+
+    include_context 'a successful compile and common tests', 'ds_agent'
+  end
+
+  context 'on Ubuntu distributions' do
+    let(:facts) do
+      {
+        osfamily: 'Debian',
+        operatingsystem: 'Ubuntu',
+        architecture: 'x86_64'
+      }
+    end
+
+    include_context 'a successful compile and common tests', 'ds-agent'
+  end
+
+  context 'on Suse distributions' do
+    let(:facts) do
+      {
+        osfamily: 'Suse',
+        operatingsystem: 'SLES',
+        architecture: 'x86_64'
+      }
+    end
+
+    include_context 'a successful compile and common tests', 'ds_agent'
+  end
+
+  context 'on Windows' do
+    let(:facts) do
+      {
+        osfamily: 'windows',
+        operatingsystem: 'Windows',
+        architecture: 'x64'
+      }
+    end
+
+    it do
+      pending 'Windows catalog fails to compile on non-Windows hosts ' \
+        'due to https://github.com/rodjek/rspec-puppet/issues/192'
+      is_expected.to compile.with_all_deps
+    end
+    it { is_expected.to contain_class('deepsecurityagent') }
+    it do
+      is_expected.to contain_package('Trend Micro Deep Security Agent')
+        .with_ensure('installed')
+    end
+    it { is_expected.to contain_service('ds_agent').with_ensure('running') }
+  end
+
+  context 'on an unsupported OS' do
+    let(:facts) do
+      {
+        osfamily: 'foo',
+        operatingsystem: 'foo',
+        architecture: 'foo'
+      }
+    end
+
+    it { is_expected.not_to compile }
+    it { is_expected.to raise_error(Puppet::Error, /Operating system is not supported by this module/) }
   end
 end


### PR DESCRIPTION
* Ensures that agent activation happens once instead of every puppet run.
* Changes notice log messages to debug messages to reduce log volume on puppet master.  Notice messages printed every run even when nothing was changing.
* Reformatted module to comply with puppet-lint.
* Add rspec-puppet tests.

Resolves #1 